### PR TITLE
api&ui: do not force http2https redirect for API endpoint

### DIFF
--- a/imageroot/actions/configure-module/30traefik
+++ b/imageroot/actions/configure-module/30traefik
@@ -56,7 +56,7 @@ response_server = agent.tasks.run(
     data={
         'instance': f"{os.environ['MODULE_ID']}-server",
         'url':  'http://127.0.0.1:' + os.environ["TCP_SERVER_PORT"],
-        'http2https': True,
+        'http2https': False,
         'lets_encrypt': config['lets_encrypt'],
         'host': config['host_server']
     },

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -26,6 +26,7 @@
     "configure_instance": "Configure {instance}",
     "save": "Save",
     "host_server": "API server host name",
+    "host_server_helper": "The API server listens both on HTTP and HTTPS ports. Use the HTTP protocol only from a private network.",
     "host_console": "Web interface host name",
     "lets_encrypt": "Let's Encrypt certificate",
     "user": "MinIO root user name",

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -25,6 +25,7 @@
               placeholder="minio.mydomain.org"
               :disabled="loading.getConfiguration || loading.configureModule"
               :invalid-message="error.host_server"
+              :helper-text="$t('settings.host_server_helper')"
               ref="host_server"
             ></cv-text-input>
             <cv-text-input


### PR DESCRIPTION
Allow access buckets from a secure network using the HTTP protocol