### PR TITLE
Fix SELinux context of data volume

### DIFF
--- a/imageroot/systemd/user/minio.service
+++ b/imageroot/systemd/user/minio.service
@@ -18,7 +18,7 @@ ExecStart=/usr/bin/podman run \
     --env=MINIO_ROOT_USER=${MINIO_ROOT_USER} \
     --env=MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD} \
     --env=MINIO_DOMAIN=${MINIO_HOST_SERVER} \
-    --volume=${MINIO_STORAGE}:/data \
+    --volume=${MINIO_STORAGE}:/data:z \
     ${MINIO_IMAGE} server /data --console-address ":9001"
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/minio.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/minio.ctr-id


### PR DESCRIPTION
Add the "shared" flag to the volume definition.

Refs: https://github.com/NethServer/dev/issues/7074

See also:
- https://danwalsh.livejournal.com/81269.html
- https://danwalsh.livejournal.com/76016.html