### PR TITLE
Change Renovate configuration to use automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>NethServer/.github:ns8"
+    "local>NethServer/.github:ns8-automerge"
   ]
 }


### PR DESCRIPTION
This pull request makes a small configuration update to the `renovate.json` file. The change switches the Renovate configuration to use the `ns8-automerge` preset, likely enabling automatic merging of dependencies.

- Updated the `renovate.json` configuration to extend from the `ns8-automerge` preset instead of `ns8`, which may enable automatic dependency merges.